### PR TITLE
Fix Google Sheets example build issues

### DIFF
--- a/Assets/1-Scripts/GoogleSheets/GoogleSheetsReader.cs
+++ b/Assets/1-Scripts/GoogleSheets/GoogleSheetsReader.cs
@@ -1,0 +1,57 @@
+using System.Collections;
+using UnityEngine;
+using UnityEngine.Networking; // requiere el paquete integrado "Unity Web Request"
+
+public class GoogleSheetsReader : MonoBehaviour
+{
+    [Tooltip("Public Google Sheets export link")] 
+    public string sheetUrl = "https://docs.google.com/spreadsheets/d/13PsACix0amVNjdoSWasaFPId-VAtGShmd6gMxgkFNy8/export?format=csv";
+
+    void Start()
+    {
+        StartCoroutine(GetSheetData());
+    }
+
+    IEnumerator GetSheetData()
+    {
+        UnityWebRequest request = UnityWebRequest.Get(sheetUrl);
+        yield return request.SendWebRequest();
+
+        if (request.result != UnityWebRequest.Result.Success)
+        {
+            Debug.LogError($"Error reading sheet: {request.error}");
+        }
+        else
+        {
+            string data = request.downloadHandler.text;
+            string[] lines = data.Split('\n');
+
+            if (lines.Length == 0)
+            {
+                Debug.LogWarning("Sheet is empty");
+                yield break;
+            }
+
+            // Use the first row as column names
+            string[] headers = lines[0].Split(',');
+
+            for (int i = 1; i < lines.Length; i++)
+            {
+                string line = lines[i].Trim();
+                if (string.IsNullOrEmpty(line))
+                    continue;
+
+                string[] values = line.Split(',');
+                System.Text.StringBuilder row = new System.Text.StringBuilder();
+
+                for (int j = 0; j < headers.Length && j < values.Length; j++)
+                {
+                    if (j > 0) row.Append(", ");
+                    row.AppendFormat("{0}: {1}", headers[j].Trim(), values[j].Trim());
+                }
+
+                Debug.Log(row.ToString());
+            }
+        }
+    }
+}

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
-    "com.unity.render-pipelines.universal": "17.0.4"
+    "com.unity.render-pipelines.universal": "17.0.4",
+    "com.unity.modules.unitywebrequest": "1.0.0"
   },
   "scopedRegistries": [
     {

--- a/README.md
+++ b/README.md
@@ -8,6 +8,15 @@ _**Repositorio destinado a albergar los datos para acceder desde los poryectos e
 
 
 </header>
+## 📊 Acceso a datos desde Google Sheets
+
+Este repositorio incluye un script de ejemplo (`GoogleSheetsReader`) para leer una hoja de cálculo pública de Google desde Unity. De esta forma puedes modificar el contenido de la hoja y reflejar los cambios en el juego sin recompilar.
+
+1. En tu hoja de cálculo selecciona **Archivo → Publicar en la Web** y copia el enlace de exportación en formato CSV.
+2. Coloca ese enlace en el campo **sheetUrl** del componente `GoogleSheetsReader`.
+3. Asegúrate de tener activado el paquete integrado **Unity Web Request** en *Package Manager* o añade la dependencia `com.unity.modules.unitywebrequest` al `manifest.json`.
+4. Ejecuta la escena y el script descargará el contenido, mostrándolo en la consola. El script interpreta la primera fila como los encabezados de columna y mostrará cada registro usando esos títulos. Puedes adaptarlo para actualizar cualquier variable de tu juego.
+
    
 <footer>
    
@@ -23,3 +32,4 @@ _**Repositorio destinado a albergar los datos para acceder desde los poryectos e
 
 
 </footer>
+


### PR DESCRIPTION
## Summary
- add `com.unity.modules.unitywebrequest` dependency
- mention enabling the Unity Web Request package in README
- clarify package requirement in `GoogleSheetsReader`
- parse CSV rows using the first row as headers

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_688b639deea8832692446204c83e3b7c