### PR TITLE
Add UI components for editing shopping lists

### DIFF
--- a/Assets/1-Scripts/ShoppingList/GoogleSheetsShoppingListWriter.cs
+++ b/Assets/1-Scripts/ShoppingList/GoogleSheetsShoppingListWriter.cs
@@ -1,0 +1,38 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Networking;
+
+public class GoogleSheetsShoppingListWriter : MonoBehaviour
+{
+    [Tooltip("URL of the Apps Script that updates the sheet")] 
+    public string scriptUrl;
+
+    public void UploadList(ShoppingListManager manager)
+    {
+        if (manager != null && !string.IsNullOrEmpty(scriptUrl))
+            StartCoroutine(UploadCoroutine(manager.lists));
+    }
+
+    IEnumerator UploadCoroutine(List<ShoppingList> lists)
+    {
+        var wrapper = new Wrapper { lists = lists };
+        string json = JsonUtility.ToJson(wrapper);
+        byte[] data = System.Text.Encoding.UTF8.GetBytes(json);
+        UnityWebRequest request = new UnityWebRequest(scriptUrl, "POST");
+        request.uploadHandler = new UploadHandlerRaw(data);
+        request.downloadHandler = new DownloadHandlerBuffer();
+        request.SetRequestHeader("Content-Type", "application/json");
+        yield return request.SendWebRequest();
+        if (request.result != UnityWebRequest.Result.Success)
+            Debug.LogError($"Error uploading list: {request.error}");
+        else
+            Debug.Log("Sheet updated");
+    }
+
+    [System.Serializable]
+    class Wrapper
+    {
+        public List<ShoppingList> lists;
+    }
+}

--- a/Assets/1-Scripts/ShoppingList/ShoppingListUI.cs
+++ b/Assets/1-Scripts/ShoppingList/ShoppingListUI.cs
@@ -1,0 +1,62 @@
+using System.Text;
+using UnityEngine;
+using UnityEngine.UI;
+
+public class ShoppingListUI : MonoBehaviour
+{
+    [Header("References")]
+    public ShoppingListManager manager;
+    public InputField listInput;
+    public InputField itemInput;
+    public InputField quantityInput;
+    public Text displayText;
+    public GoogleSheetsShoppingListWriter writer;
+
+    void Start()
+    {
+        RefreshDisplay();
+    }
+
+    public void AddItem()
+    {
+        if (manager == null) return;
+        string listName = string.IsNullOrEmpty(listInput.text) ? "List" : listInput.text;
+        string itemName = itemInput.text;
+        if (string.IsNullOrEmpty(itemName)) return;
+        int qty = 0;
+        int.TryParse(quantityInput.text, out qty);
+        manager.AddItem(listName, itemName, qty);
+        RefreshDisplay();
+        if (writer != null)
+            writer.UploadList(manager);
+    }
+
+    public void RemoveItem()
+    {
+        if (manager == null) return;
+        string listName = string.IsNullOrEmpty(listInput.text) ? "List" : listInput.text;
+        var list = manager.lists.Find(l => l.name == listName);
+        if (list == null) return;
+        var item = list.items.Find(i => i.name == itemInput.text);
+        if (item != null)
+            list.items.Remove(item);
+        RefreshDisplay();
+        if (writer != null)
+            writer.UploadList(manager);
+    }
+
+    public void RefreshDisplay()
+    {
+        if (displayText == null || manager == null) return;
+        StringBuilder sb = new StringBuilder();
+        foreach (var list in manager.lists)
+        {
+            sb.AppendLine(list.name);
+            foreach (var item in list.items)
+            {
+                sb.AppendFormat("- {0} ({1})\n", item.name, item.quantity);
+            }
+        }
+        displayText.text = sb.ToString();
+    }
+}

--- a/README.md
+++ b/README.md
@@ -33,6 +33,15 @@ Se ha añadido un conjunto de scripts en `Assets/1-Scripts/ShoppingList` que pro
 El componente permite indicar en el inspector los encabezados de columna que corresponden al nombre de la lista, el artículo y la cantidad. De este modo puedes usar títulos personalizados en la primera fila de tu hoja de cálculo. Si no incluyes la columna de lista, todos los elementos se añadirán a la lista indicada en `defaultListName`.
 Estos componentes sirven como base para desarrollar la funcionalidad de la aplicación sin necesidad de recompilar cada vez que cambien los datos.
 
+### Gestión de la lista desde la interfaz
+
+Se han añadido dos scripts para manipular las listas en tiempo de ejecución:
+
+- **ShoppingListUI**: muestra el contenido del `ShoppingListManager` y permite añadir o eliminar elementos mediante campos de entrada y botones.
+- **GoogleSheetsShoppingListWriter**: envía los cambios a un script web para actualizar la hoja de cálculo mediante una petición `POST` en formato JSON.
+
+Vincula estos componentes a tu panel de UI para editar las listas desde Unity y mantener la hoja de cálculo sincronizada.
+
    
 <footer>
    


### PR DESCRIPTION
## Summary
- add `ShoppingListUI` to manage lists via buttons and input fields
- add `GoogleSheetsShoppingListWriter` to sync changes back to the sheet
- document new UI functionality in the README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_688bea981b00832680ce0387c8847592