### PR TITLE
Fix swipe item reset

### DIFF
--- a/Assets/1-Scripts/SwipeToDeleteItem.cs
+++ b/Assets/1-Scripts/SwipeToDeleteItem.cs
@@ -2,7 +2,7 @@
 using UnityEngine;
 using UnityEngine.EventSystems;
 
-public class SwipeToDeleteItem : MonoBehaviour, IPointerDownHandler
+public class SwipeToDeleteItem : MonoBehaviour, IPointerDownHandler, IPointerUpHandler
 {
     private RectTransform rectTransform;
     private Vector2 originalPos;
@@ -33,6 +33,16 @@ public class SwipeToDeleteItem : MonoBehaviour, IPointerDownHandler
     {
         isListening = true;
         Debug.Log("🟢 PointerDown: Escuchando swipe");
+    }
+
+    public void OnPointerUp(PointerEventData eventData)
+    {
+        if (!isListening)
+            return;
+
+        Debug.Log("🔴 PointerUp: Cancelar swipe");
+        rectTransform.anchoredPosition = originalPos;
+        isListening = false;
     }
 
     private void OnSwipePercentage(Dictionary<string, float> percentages)


### PR DESCRIPTION
## Summary
- add `IPointerUpHandler` to `SwipeToDeleteItem`
- reset item position when the pointer is released without a full swipe

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_688d3d10054483269d3bb686726d803d