### PR TITLE
Add position tracking and sheet refresh for shopping lists

### DIFF
--- a/AppsScript.gs
+++ b/AppsScript.gs
@@ -1,0 +1,31 @@
+function doGet() {
+  const sheet = SpreadsheetApp.getActiveSpreadsheet().getActiveSheet();
+  const data = sheet.getDataRange().getValues();
+  const headers = data.shift();
+  const lists = {};
+  data.forEach(row => {
+    const listName = row[0];
+    const itemName = row[1];
+    const quantity = row[2];
+    const position = row[3];
+    if (!lists[listName]) {
+      lists[listName] = { name: listName, items: [] };
+    }
+    lists[listName].items.push({ name: itemName, quantity: quantity, position: position });
+  });
+  return ContentService.createTextOutput(JSON.stringify({ lists: Object.values(lists) }))
+    .setMimeType(ContentService.MimeType.JSON);
+}
+
+function doPost(e) {
+  const data = JSON.parse(e.postData.contents);
+  const sheet = SpreadsheetApp.getActiveSpreadsheet().getActiveSheet();
+  sheet.clear();
+  sheet.appendRow(['List', 'Item', 'Units', 'Position']);
+  data.lists.forEach(list => {
+    list.items.forEach(item => {
+      sheet.appendRow([list.name, item.name, item.quantity, item.position]);
+    });
+  });
+  return ContentService.createTextOutput('OK');
+}

--- a/Assets/1-Scripts/ShoppingList/GoogleSheetsShoppingListLoader.cs
+++ b/Assets/1-Scripts/ShoppingList/GoogleSheetsShoppingListLoader.cs
@@ -18,15 +18,40 @@ public class GoogleSheetsShoppingListLoader : MonoBehaviour
     public string itemHeader = "Item";
     [Tooltip("Column used for the item quantity")]
     public string quantityHeader = "Units";
+    [Tooltip("Column used for the item position (optional)")]
+    public string positionHeader = "Position";
     [Tooltip("Name used when no list column is present")]
     public string defaultListName = "List";
+
+    [Tooltip("Reload data every N seconds (0 disables auto refresh)")]
+    public float refreshInterval = 0f;
 
     void Start()
     {
         if (manager != null && !string.IsNullOrEmpty(sheetUrl))
-            StartCoroutine(Load());
+        {
+            Refresh();
+            if (refreshInterval > 0f)
+                StartCoroutine(RefreshPeriodically());
+        }
         else
             Debug.LogWarning("Loader requires a manager and sheet URL");
+    }
+
+    public void Refresh()
+    {
+        if (manager == null) return;
+        manager.lists.Clear();
+        StartCoroutine(Load());
+    }
+
+    IEnumerator RefreshPeriodically()
+    {
+        while (true)
+        {
+            yield return new WaitForSeconds(refreshInterval);
+            Refresh();
+        }
     }
 
     IEnumerator Load()
@@ -48,6 +73,7 @@ public class GoogleSheetsShoppingListLoader : MonoBehaviour
         int listCol = System.Array.IndexOf(headers, listHeader);
         int itemCol = System.Array.IndexOf(headers, itemHeader);
         int qtyCol = System.Array.IndexOf(headers, quantityHeader);
+        int posCol = System.Array.IndexOf(headers, positionHeader);
 
 
         for (int i = 1; i < lines.Length; i++)
@@ -61,13 +87,16 @@ public class GoogleSheetsShoppingListLoader : MonoBehaviour
 
             string itemName = itemCol >= 0 && itemCol < values.Length ? values[itemCol].Trim() : string.Empty;
             string qtyStr = qtyCol >= 0 && qtyCol < values.Length ? values[qtyCol].Trim() : "0";
+            string posStr = posCol >= 0 && posCol < values.Length ? values[posCol].Trim() : "-1";
             int qty = 0;
             int.TryParse(qtyStr, out qty);
+            int pos = -1;
+            int.TryParse(posStr, out pos);
 
             if (string.IsNullOrEmpty(itemName))
                 continue;
 
-            manager.AddItem(listName, itemName, qty);
+            manager.AddItem(listName, itemName, qty, pos);
 
         }
 

--- a/Assets/1-Scripts/ShoppingList/ShoppingItem.cs
+++ b/Assets/1-Scripts/ShoppingList/ShoppingItem.cs
@@ -5,4 +5,5 @@ public class ShoppingItem
 {
     public string name;
     public int quantity;
+    public int position;
 }

--- a/Assets/1-Scripts/ShoppingList/ShoppingListManager.cs
+++ b/Assets/1-Scripts/ShoppingList/ShoppingListManager.cs
@@ -10,7 +10,7 @@ public class ShoppingListManager : MonoBehaviour
         lists.Add(new ShoppingList { name = name });
     }
 
-    public void AddItem(string listName, string itemName, int quantity)
+    public void AddItem(string listName, string itemName, int quantity, int position = -1)
     {
         var list = lists.Find(l => l.name == listName);
         if (list == null)
@@ -18,6 +18,29 @@ public class ShoppingListManager : MonoBehaviour
             list = new ShoppingList { name = listName };
             lists.Add(list);
         }
-        list.items.Add(new ShoppingItem { name = itemName, quantity = quantity });
+
+        var item = new ShoppingItem { name = itemName, quantity = quantity };
+
+        if (position >= 0 && position <= list.items.Count)
+            list.items.Insert(position, item);
+        else
+            list.items.Add(item);
+
+        for (int i = 0; i < list.items.Count; i++)
+            list.items[i].position = i;
+    }
+
+    public void RemoveItem(string listName, string itemName)
+    {
+        var list = lists.Find(l => l.name == listName);
+        if (list == null) return;
+
+        var item = list.items.Find(i => i.name == itemName);
+        if (item == null) return;
+
+        list.items.Remove(item);
+
+        for (int i = 0; i < list.items.Count; i++)
+            list.items[i].position = i;
     }
 }

--- a/Assets/1-Scripts/ShoppingList/ShoppingListUI.cs
+++ b/Assets/1-Scripts/ShoppingList/ShoppingListUI.cs
@@ -9,6 +9,7 @@ public class ShoppingListUI : MonoBehaviour
     public InputField listInput;
     public InputField itemInput;
     public InputField quantityInput;
+    public InputField positionInput;
     public Text displayText;
     public GoogleSheetsShoppingListWriter writer;
 
@@ -25,7 +26,10 @@ public class ShoppingListUI : MonoBehaviour
         if (string.IsNullOrEmpty(itemName)) return;
         int qty = 0;
         int.TryParse(quantityInput.text, out qty);
-        manager.AddItem(listName, itemName, qty);
+        int pos = -1;
+        if (positionInput != null)
+            int.TryParse(positionInput.text, out pos);
+        manager.AddItem(listName, itemName, qty, pos);
         RefreshDisplay();
         if (writer != null)
             writer.UploadList(manager);
@@ -35,11 +39,7 @@ public class ShoppingListUI : MonoBehaviour
     {
         if (manager == null) return;
         string listName = string.IsNullOrEmpty(listInput.text) ? "List" : listInput.text;
-        var list = manager.lists.Find(l => l.name == listName);
-        if (list == null) return;
-        var item = list.items.Find(i => i.name == itemInput.text);
-        if (item != null)
-            list.items.Remove(item);
+        manager.RemoveItem(listName, itemInput.text);
         RefreshDisplay();
         if (writer != null)
             writer.UploadList(manager);
@@ -54,7 +54,7 @@ public class ShoppingListUI : MonoBehaviour
             sb.AppendLine(list.name);
             foreach (var item in list.items)
             {
-                sb.AppendFormat("- {0} ({1})\n", item.name, item.quantity);
+                sb.AppendFormat("{0}. {1} ({2})\n", item.position, item.name, item.quantity);
             }
         }
         displayText.text = sb.ToString();

--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ Este repositorio incluye un script de ejemplo (`GoogleSheetsReader`) para leer u
 
 Se ha añadido un conjunto de scripts en `Assets/1-Scripts/ShoppingList` que proporcionan la estructura mínima para una aplicación de listas:
 
-- **ShoppingItem**: almacena el nombre del artículo y la cantidad.
+- **ShoppingItem**: almacena el nombre del artículo, la cantidad y la posición dentro de la lista.
 - **ShoppingList**: agrupa varios `ShoppingItem` bajo un nombre de lista.
 - **ShoppingListManager**: permite crear listas y añadir elementos desde código.
-- **GoogleSheetsShoppingListLoader**: lee una hoja de cálculo publicada en formato CSV e incorpora los datos al `ShoppingListManager`.
+- **GoogleSheetsShoppingListLoader**: lee una hoja de cálculo publicada en formato CSV e incorpora los datos al `ShoppingListManager`, con soporte opcional de recarga periódica.
 
 
 El componente permite indicar en el inspector los encabezados de columna que corresponden al nombre de la lista, el artículo y la cantidad. De este modo puedes usar títulos personalizados en la primera fila de tu hoja de cálculo. Si no incluyes la columna de lista, todos los elementos se añadirán a la lista indicada en `defaultListName`.


### PR DESCRIPTION
## Summary
- track item ordering with new position field and manager helpers
- sync changes via Apps Script and auto-refresh loader
- expose position input in UI for list editing

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_b_688ddaa51b1c8326a466be0709ddc57f