### PR TITLE
Separate completed shopping items in UI

### DIFF
--- a/Assets/1-Scripts/ShoppingList/ShoppingListItemUI.cs
+++ b/Assets/1-Scripts/ShoppingList/ShoppingListItemUI.cs
@@ -18,7 +18,10 @@ public class ShoppingListItemUI : MonoBehaviour
         if (swipe == null)
             swipe = GetComponentInChildren<SwipeToDeleteItem>();
         if (swipe != null)
+        {
             swipe.onDelete.AddListener(OnDelete);
+            swipe.onComplete.AddListener(OnComplete);
+        }
     }
 
     void Start()
@@ -63,9 +66,23 @@ public class ShoppingListItemUI : MonoBehaviour
         }
     }
 
+    void OnComplete()
+    {
+        if (manager != null)
+        {
+            manager.SetItemCompleted(listName, item.name, true);
+            Refresh();
+            if (writer != null)
+                writer.UploadList(manager);
+        }
+    }
+
     void OnDestroy()
     {
         if (swipe != null)
+        {
             swipe.onDelete.RemoveListener(OnDelete);
+            swipe.onComplete.RemoveListener(OnComplete);
+        }
     }
 }

--- a/Assets/1-Scripts/ShoppingList/ShoppingListUI.cs
+++ b/Assets/1-Scripts/ShoppingList/ShoppingListUI.cs
@@ -10,6 +10,7 @@ public class ShoppingListUI : MonoBehaviour
     public InputField quantityInput;
     public InputField positionInput;
     public Transform itemContainer;
+    public Transform completedItemContainer;
     public GameObject itemPrefab;
     public GoogleSheetsShoppingListWriter writer;
 
@@ -57,12 +58,18 @@ public class ShoppingListUI : MonoBehaviour
 
         foreach (Transform child in itemContainer)
             Destroy(child.gameObject);
+        if (completedItemContainer != null)
+        {
+            foreach (Transform child in completedItemContainer)
+                Destroy(child.gameObject);
+        }
 
         foreach (var list in manager.lists)
         {
             foreach (var item in list.items)
             {
-                GameObject go = Instantiate(itemPrefab, itemContainer);
+                Transform parent = item.completed && completedItemContainer != null ? completedItemContainer : itemContainer;
+                GameObject go = Instantiate(itemPrefab, parent);
                 go.transform.SetSiblingIndex(item.position);
                 var ui = go.GetComponentInChildren<ShoppingListItemUI>();
                 if (ui != null)


### PR DESCRIPTION
## Summary
- Add container for completed shopping items and place completed entries there
- Handle swipe completion to mark items done and sync with writer

## Testing
- `mcs Assets/1-Scripts/ShoppingList/ShoppingListUI.cs Assets/1-Scripts/ShoppingList/ShoppingListItemUI.cs Assets/1-Scripts/ShoppingList/ShoppingItem.cs Assets/1-Scripts/ShoppingList/ShoppingListManager.cs` *(fails: The type or namespace name `UnityEngine` could not be found)*

------
https://chatgpt.com/codex/tasks/task_b_688fa07664708326b0549ed1b7877ffa