### PR TITLE
Add completed status to shopping list sync

### DIFF
--- a/AppsScript.gs
+++ b/AppsScript.gs
@@ -8,10 +8,11 @@ function doGet() {
     const itemName = row[1];
     const quantity = row[2];
     const position = row[3];
+    const completed = row[4];
     if (!lists[listName]) {
       lists[listName] = { name: listName, items: [] };
     }
-    lists[listName].items.push({ name: itemName, quantity: quantity, position: position });
+    lists[listName].items.push({ name: itemName, quantity: quantity, position: position, completed: completed });
   });
   return ContentService.createTextOutput(JSON.stringify({ lists: Object.values(lists) }))
     .setMimeType(ContentService.MimeType.JSON);
@@ -21,10 +22,10 @@ function doPost(e) {
   const data = JSON.parse(e.postData.contents);
   const sheet = SpreadsheetApp.getActiveSpreadsheet().getActiveSheet();
   sheet.clear();
-  sheet.appendRow(['List', 'Item', 'Units', 'Position']);
+  sheet.appendRow(['List', 'Item', 'Units', 'Position', 'Completed']);
   data.lists.forEach(list => {
     list.items.forEach(item => {
-      sheet.appendRow([list.name, item.name, item.quantity, item.position]);
+      sheet.appendRow([list.name, item.name, item.quantity, item.position, item.completed]);
     });
   });
   return ContentService.createTextOutput('OK');

--- a/Assets/1-Scripts/ShoppingList/GoogleSheetsShoppingListLoader.cs
+++ b/Assets/1-Scripts/ShoppingList/GoogleSheetsShoppingListLoader.cs
@@ -20,6 +20,8 @@ public class GoogleSheetsShoppingListLoader : MonoBehaviour
     public string quantityHeader = "Units";
     [Tooltip("Column used for the item position (optional)")]
     public string positionHeader = "Position";
+    [Tooltip("Column used for the item completion state (optional)")]
+    public string completedHeader = "Completed";
     [Tooltip("Name used when no list column is present")]
     public string defaultListName = "List";
 
@@ -73,6 +75,7 @@ public class GoogleSheetsShoppingListLoader : MonoBehaviour
         int itemCol = System.Array.IndexOf(headers, itemHeader);
         int qtyCol = System.Array.IndexOf(headers, quantityHeader);
         int posCol = System.Array.IndexOf(headers, positionHeader);
+        int completedCol = System.Array.IndexOf(headers, completedHeader);
 
         manager.BeginUpdate();
         manager.Clear();
@@ -89,17 +92,20 @@ public class GoogleSheetsShoppingListLoader : MonoBehaviour
             string itemName = itemCol >= 0 && itemCol < values.Length ? StripQuotes(values[itemCol]) : string.Empty;
             string qtyStr = qtyCol >= 0 && qtyCol < values.Length ? StripQuotes(values[qtyCol]) : "0";
             string posStr = posCol >= 0 && posCol < values.Length ? StripQuotes(values[posCol]) : "-1";
+            string completedStr = completedCol >= 0 && completedCol < values.Length ? StripQuotes(values[completedCol]) : "false";
             int qty = 0;
             int.TryParse(qtyStr, out qty);
             int pos = -1;
             int.TryParse(posStr, out pos);
+            bool completed = false;
+            bool.TryParse(completedStr, out completed);
 
             if (string.IsNullOrEmpty(itemName))
                 continue;
 
             int row = i + 1; // 1-based row index including header
             int column = itemCol >= 0 ? itemCol + 1 : -1;
-            manager.AddItem(listName, itemName, qty, pos, row, column);
+            manager.AddItem(listName, itemName, qty, pos, row, column, completed);
         }
 
         manager.EndUpdate();

--- a/Assets/1-Scripts/ShoppingList/GoogleSheetsShoppingListWriter.cs
+++ b/Assets/1-Scripts/ShoppingList/GoogleSheetsShoppingListWriter.cs
@@ -16,7 +16,24 @@ public class GoogleSheetsShoppingListWriter : MonoBehaviour
 
     IEnumerator UploadCoroutine(List<ShoppingList> lists)
     {
-        var wrapper = new Wrapper { lists = lists };
+        var serializableLists = new List<SerializableList>();
+        foreach (var list in lists)
+        {
+            var sList = new SerializableList { name = list.name, items = new List<SerializableItem>() };
+            foreach (var item in list.items)
+            {
+                sList.items.Add(new SerializableItem
+                {
+                    name = item.name,
+                    quantity = item.quantity,
+                    position = item.position,
+                    completed = item.completed
+                });
+            }
+            serializableLists.Add(sList);
+        }
+
+        var wrapper = new Wrapper { lists = serializableLists };
         string json = JsonUtility.ToJson(wrapper);
         byte[] data = System.Text.Encoding.UTF8.GetBytes(json);
         UnityWebRequest request = new UnityWebRequest(scriptUrl, "POST");
@@ -33,6 +50,22 @@ public class GoogleSheetsShoppingListWriter : MonoBehaviour
     [System.Serializable]
     class Wrapper
     {
-        public List<ShoppingList> lists;
+        public List<SerializableList> lists;
+    }
+
+    [System.Serializable]
+    class SerializableList
+    {
+        public string name;
+        public List<SerializableItem> items;
+    }
+
+    [System.Serializable]
+    class SerializableItem
+    {
+        public string name;
+        public int quantity;
+        public int position;
+        public bool completed;
     }
 }


### PR DESCRIPTION
## Summary
- add Completed column for Apps Script list syncing
- load Completed value from Google Sheets into ShoppingItem
- send item.completed when uploading shopping lists

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_688fa23e9fac832692619c11e7049598