### PR TITLE
Fix swipe direction and sync item state to sheet

### DIFF
--- a/AppsScript.gs
+++ b/AppsScript.gs
@@ -1,14 +1,24 @@
 function doGet() {
   const sheet = SpreadsheetApp.getActiveSpreadsheet().getActiveSheet();
   const data = sheet.getDataRange().getValues();
-  const headers = data.shift();
+  if (data.length === 0) {
+    return ContentService.createTextOutput(JSON.stringify({ lists: [] }))
+      .setMimeType(ContentService.MimeType.JSON);
+  }
+  const headers = data.shift().map(h => h.toString().trim());
+  const listIdx = headers.indexOf('List');
+  const itemIdx = headers.indexOf('Item');
+  const qtyIdx = headers.indexOf('Units');
+  const posIdx = headers.indexOf('Position');
+  const completedIdx = headers.indexOf('Completed');
   const lists = {};
   data.forEach(row => {
-    const listName = row[0];
-    const itemName = row[1];
-    const quantity = row[2];
-    const position = row[3];
-    const completed = row[4];
+    const listName = listIdx >= 0 ? row[listIdx] : 'List';
+    const itemName = itemIdx >= 0 ? row[itemIdx] : '';
+    if (!itemName) return;
+    const quantity = qtyIdx >= 0 ? row[qtyIdx] : 0;
+    const position = posIdx >= 0 ? row[posIdx] : -1;
+    const completed = completedIdx >= 0 ? row[completedIdx] : false;
     if (!lists[listName]) {
       lists[listName] = { name: listName, items: [] };
     }
@@ -23,9 +33,11 @@ function doPost(e) {
   const sheet = SpreadsheetApp.getActiveSpreadsheet().getActiveSheet();
   sheet.clear();
   sheet.appendRow(['List', 'Item', 'Units', 'Position', 'Completed']);
-  data.lists.forEach(list => {
-    list.items.forEach(item => {
-      sheet.appendRow([list.name, item.name, item.quantity, item.position, item.completed]);
+  data.lists.forEach(function(list) {
+    list.items.forEach(function(item, index) {
+      const pos = (item.position !== undefined && item.position !== null) ? item.position : index;
+      const completed = item.completed === true || item.completed === 'true';
+      sheet.appendRow([list.name, item.name, item.quantity, pos, completed]);
     });
   });
   return ContentService.createTextOutput('OK');

--- a/Assets/1-Scripts/ShoppingList/GoogleSheetsShoppingListLoader.cs
+++ b/Assets/1-Scripts/ShoppingList/GoogleSheetsShoppingListLoader.cs
@@ -70,13 +70,18 @@ public class GoogleSheetsShoppingListLoader : MonoBehaviour
         if (lines.Length == 0)
             yield break;
 
-        string[] headers = lines[0].Split(',');
+        // Trim the header line and each column title to avoid issues with
+        // Windows line endings or extra whitespace that prevent column
+        // detection (e.g. "Units\r" not matching "Units").
+        string[] headers = lines[0].Trim().Split(',');
+        for (int i = 0; i < headers.Length; i++)
+            headers[i] = StripQuotes(headers[i]);
+
         int listCol = System.Array.IndexOf(headers, listHeader);
         int itemCol = System.Array.IndexOf(headers, itemHeader);
         int qtyCol = System.Array.IndexOf(headers, quantityHeader);
         int posCol = System.Array.IndexOf(headers, positionHeader);
         int completedCol = System.Array.IndexOf(headers, completedHeader);
-
         manager.BeginUpdate();
         manager.Clear();
 

--- a/Assets/1-Scripts/ShoppingList/GoogleSheetsShoppingListWriter.cs
+++ b/Assets/1-Scripts/ShoppingList/GoogleSheetsShoppingListWriter.cs
@@ -5,8 +5,34 @@ using UnityEngine.Networking;
 
 public class GoogleSheetsShoppingListWriter : MonoBehaviour
 {
-    [Tooltip("URL of the Apps Script that updates the sheet")] 
+    [Tooltip("URL of the Apps Script that updates the sheet")]
     public string scriptUrl;
+
+    [Tooltip("Manager whose data will be uploaded")]
+    public ShoppingListManager manager;
+
+    void Start()
+    {
+        if (manager == null)
+            manager = FindAnyObjectByType<ShoppingListManager>();
+        if (manager != null)
+        {
+            manager.ListsChanged += OnListsChanged;
+            // Push current data so new columns like Position/Completed exist
+            UploadList(manager);
+        }
+    }
+
+    void OnDestroy()
+    {
+        if (manager != null)
+            manager.ListsChanged -= OnListsChanged;
+    }
+
+    void OnListsChanged()
+    {
+        UploadList(manager);
+    }
 
     public void UploadList(ShoppingListManager manager)
     {

--- a/Assets/1-Scripts/ShoppingList/ShoppingListItemUI.cs
+++ b/Assets/1-Scripts/ShoppingList/ShoppingListItemUI.cs
@@ -9,7 +9,6 @@ public class ShoppingListItemUI : MonoBehaviour
 
     // Expose the data this prefab represents
     public ShoppingListManager manager;
-    public GoogleSheetsShoppingListWriter writer;
     public string listName;
     public ShoppingItem item;
 
@@ -28,17 +27,13 @@ public class ShoppingListItemUI : MonoBehaviour
     {
         if (manager == null)
             manager = FindAnyObjectByType<ShoppingListManager>();
-        if (writer == null)
-            writer = FindAnyObjectByType<GoogleSheetsShoppingListWriter>();
         Refresh();
     }
 
-    public void Setup(ShoppingListManager manager, GoogleSheetsShoppingListWriter writer, string listName, ShoppingItem item)
+    public void Setup(ShoppingListManager manager, string listName, ShoppingItem item)
     {
         if (manager != null)
             this.manager = manager;
-        if (writer != null)
-            this.writer = writer;
         this.listName = listName;
         this.item = item;
         if (this.item != null)
@@ -61,8 +56,6 @@ public class ShoppingListItemUI : MonoBehaviour
         if (manager != null)
         {
             manager.RemoveItem(listName, item.name);
-            if (writer != null)
-                writer.UploadList(manager);
         }
     }
 
@@ -70,10 +63,9 @@ public class ShoppingListItemUI : MonoBehaviour
     {
         if (manager != null)
         {
-            manager.SetItemCompleted(listName, item.name, true);
+            // Toggle the completed state so repeated swipes can undo
+            manager.SetItemCompleted(listName, item.name, !item.completed);
             Refresh();
-            if (writer != null)
-                writer.UploadList(manager);
         }
     }
 

--- a/Assets/1-Scripts/ShoppingList/ShoppingListUI.cs
+++ b/Assets/1-Scripts/ShoppingList/ShoppingListUI.cs
@@ -12,7 +12,6 @@ public class ShoppingListUI : MonoBehaviour
     public Transform itemContainer;
     public Transform completedItemContainer;
     public GameObject itemPrefab;
-    public GoogleSheetsShoppingListWriter writer;
 
     void Start()
     {
@@ -39,8 +38,6 @@ public class ShoppingListUI : MonoBehaviour
         if (positionInput != null)
             int.TryParse(positionInput.text, out pos);
         manager.AddItem(listName, itemName, qty, pos);
-        if (writer != null)
-            writer.UploadList(manager);
     }
 
     public void RemoveItem()
@@ -48,8 +45,6 @@ public class ShoppingListUI : MonoBehaviour
         if (manager == null) return;
         string listName = string.IsNullOrEmpty(listInput.text) ? "List" : listInput.text;
         manager.RemoveItem(listName, itemInput.text);
-        if (writer != null)
-            writer.UploadList(manager);
     }
 
     public void RebuildItems()
@@ -73,7 +68,7 @@ public class ShoppingListUI : MonoBehaviour
                 go.transform.SetSiblingIndex(item.position);
                 var ui = go.GetComponentInChildren<ShoppingListItemUI>();
                 if (ui != null)
-                    ui.Setup(manager, writer, list.name, item);
+                    ui.Setup(manager, list.name, item);
             }
         }
     }

--- a/Assets/1-Scripts/SwipeToDelete/SwipeToDeleteItem.cs
+++ b/Assets/1-Scripts/SwipeToDelete/SwipeToDeleteItem.cs
@@ -49,13 +49,13 @@ public class SwipeToDeleteItem : MonoBehaviour, IPointerDownHandler, IDragHandle
         dragging = false;
         float finalDelta = rectTransform.anchoredPosition.x - originalPos.x;
 
-        if (finalDelta >= deleteThreshold)
+        if (finalDelta <= -deleteThreshold)
         {
             Debug.Log("💥 Item eliminado por swipe");
             onDelete.Invoke();
             Destroy(gameObject.transform.parent.gameObject);
         }
-        else if (finalDelta <= -deleteThreshold)
+        else if (finalDelta >= deleteThreshold)
         {
             Debug.Log("✅ Item completado por swipe");
             layoutElement.ignoreLayout = false;


### PR DESCRIPTION
## Summary
- Ensure Apps Script saves item `Position` and `Completed` values so changes persist in Google Sheets.
- Upload list on startup and toggle completion state via swipe for accurate sheet updates.

## Testing
- `apt-get update`
- `apt-get install -y mono-mcs`
- `mcs Assets/1-Scripts/ShoppingList/GoogleSheetsShoppingListWriter.cs Assets/1-Scripts/ShoppingList/ShoppingListItemUI.cs Assets/1-Scripts/ShoppingList/ShoppingListUI.cs Assets/1-Scripts/SwipeToDelete/SwipeToDeleteItem.cs` *(fails: UnityEngine namespace not found)*

------
https://chatgpt.com/codex/tasks/task_b_688fa7a1296c8326887f8788f8113fbf