### PR TITLE
Ensure ShoppingListItemUI locates inactive editor

### DIFF
--- a/Assets/1-Scripts/ShoppingList/ShoppingListItemUI.cs
+++ b/Assets/1-Scripts/ShoppingList/ShoppingListItemUI.cs
@@ -31,7 +31,7 @@ public class ShoppingListItemUI : MonoBehaviour
         if (manager == null)
             manager = FindAnyObjectByType<ShoppingListManager>();
         if (editor == null)
-            editor = FindAnyObjectByType<ShoppingListItemEditorUI>();
+            editor = FindObjectOfType<ShoppingListItemEditorUI>(true); // include inactive objects
         Refresh();
     }
 


### PR DESCRIPTION
## Summary
- include inactive ShoppingListItemEditorUI when locating editor in `ShoppingListItemUI`

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: Unable to locate package)*
- `mcs --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689081d0756083269d554bc56bdc88d5