### PR TITLE
refactor: inject dependencies into item ui

### DIFF
--- a/Assets/1-Scripts/ShoppingList/ShoppingListItemUI.cs
+++ b/Assets/1-Scripts/ShoppingList/ShoppingListItemUI.cs
@@ -9,8 +9,8 @@ public class ShoppingListItemUI : MonoBehaviour
     public SwipeToDeleteItem swipe;
 
     // Expose the data this prefab represents
-    public ShoppingListManager manager;
-    public ShoppingListItemEditorUI editor;
+    [SerializeField] private ShoppingListManager manager;
+    [SerializeField] private ShoppingListItemEditorUI editor;
     public string listName;
     public ShoppingItem item;
 
@@ -28,17 +28,15 @@ public class ShoppingListItemUI : MonoBehaviour
 
     void Start()
     {
-        if (manager == null)
-            manager = FindAnyObjectByType<ShoppingListManager>();
-        if (editor == null)
-            editor = FindObjectOfType<ShoppingListItemEditorUI>(true); // include inactive objects
         Refresh();
     }
 
-    public void Setup(ShoppingListManager manager, string listName, ShoppingItem item)
+    public void Setup(ShoppingListManager manager, string listName, ShoppingItem item, ShoppingListItemEditorUI editor = null)
     {
         if (manager != null)
             this.manager = manager;
+        if (editor != null)
+            this.editor = editor;
         this.listName = listName;
         this.item = item;
         if (this.item != null)

--- a/Assets/1-Scripts/ShoppingList/ShoppingListUI.cs
+++ b/Assets/1-Scripts/ShoppingList/ShoppingListUI.cs
@@ -13,6 +13,7 @@ public class ShoppingListUI : MonoBehaviour
     public Transform itemContainer;
     public Transform completedItemContainer;
     public GameObject itemPrefab;
+    public ShoppingListItemEditorUI editor;
 
     void Start()
     {
@@ -76,7 +77,7 @@ public class ShoppingListUI : MonoBehaviour
                 go.transform.SetSiblingIndex(item.position);
                 var ui = go.GetComponentInChildren<ShoppingListItemUI>();
                 if (ui != null)
-                    ui.Setup(manager, list.name, item);
+                    ui.Setup(manager, list.name, item, editor);
             }
         }
 


### PR DESCRIPTION
## Summary
- avoid FindObject calls in ShoppingListItemUI by serializing manager and editor references
- allow ShoppingListUI to provide editor when instantiating items

## Testing
- `dotnet test` *(fails: MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_b_6891c283764c832682507b35e9f1b391