### PR TITLE
Ensure uploads finish on application quit

### DIFF
--- a/Assets/1-Scripts/ShoppingList/GoogleSheetsShoppingListWriter.cs
+++ b/Assets/1-Scripts/ShoppingList/GoogleSheetsShoppingListWriter.cs
@@ -39,9 +39,23 @@ public class GoogleSheetsShoppingListWriter : MonoBehaviour
             QueueUpload();
     }
 
-    void OnApplicationQuit()
+    IEnumerator OnApplicationQuit()
     {
-        QueueUpload();
+        // If there's nothing to upload just exit immediately
+        if (manager == null || string.IsNullOrEmpty(scriptUrl))
+            yield break;
+
+        // If an upload is already running wait for it to finish,
+        // otherwise perform a final upload and wait for the request
+        if (uploadInProgress)
+        {
+            while (uploadInProgress)
+                yield return null;
+        }
+        else
+        {
+            yield return UploadCoroutine(manager.lists);
+        }
     }
 
     void OnListsChanged() => QueueUpload();


### PR DESCRIPTION
## Summary
- wait for ongoing or pending uploads inside `OnApplicationQuit`

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_b_6891c2947454832691d8fb99969a7759