### PR TITLE
Defer disk save during batch updates

### DIFF
--- a/Assets/1-Scripts/ShoppingList/ShoppingListManager.cs
+++ b/Assets/1-Scripts/ShoppingList/ShoppingListManager.cs
@@ -10,6 +10,7 @@ public class ShoppingListManager : MonoBehaviour
     public event Action ListsChanged;
 
     bool suppressEvents = false;
+    bool needsSave = false;
     string SavePath => Path.Combine(Application.persistentDataPath, "shoppingLists.json");
 
     void Awake()
@@ -19,17 +20,32 @@ public class ShoppingListManager : MonoBehaviour
 
     void NotifyChanged()
     {
-        if (!suppressEvents)
-            ListsChanged?.Invoke();
+        if (suppressEvents)
+        {
+            needsSave = true;
+            return;
+        }
+
+        ListsChanged?.Invoke();
         SaveToDisk();
     }
 
-    public void BeginUpdate() => suppressEvents = true;
+    public void BeginUpdate()
+    {
+        suppressEvents = true;
+        needsSave = false;
+    }
 
     public void EndUpdate()
     {
         suppressEvents = false;
-        NotifyChanged();
+        if (needsSave)
+        {
+            needsSave = false;
+            SaveToDisk();
+        }
+
+        ListsChanged?.Invoke();
     }
 
     public void Clear()


### PR DESCRIPTION
## Summary
- avoid saving shopping lists to disk when events are suppressed
- save once and raise change event after batch updates

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_b_6891c4dd4f608326ad1fef0f573ba90a