### PR TITLE
Use event callbacks for swipe deletion in shopping list UI

### DIFF
--- a/Assets/1-Scripts/ShoppingList/ShoppingListItemUI.cs
+++ b/Assets/1-Scripts/ShoppingList/ShoppingListItemUI.cs
@@ -67,6 +67,8 @@ public class ShoppingListItemUI : MonoBehaviour
         if (manager != null)
         {
             manager.RemoveItem(listName, item.id);
+            // Once the manager has been updated, remove this UI element.
+            Destroy(gameObject);
         }
     }
 

--- a/Assets/1-Scripts/ShoppingList/ShoppingListUI.cs
+++ b/Assets/1-Scripts/ShoppingList/ShoppingListUI.cs
@@ -60,6 +60,8 @@ public class ShoppingListUI : MonoBehaviour
     {
         if (manager == null || itemContainer == null || itemPrefab == null) return;
 
+        // Start from a clean slate and recreate the entire UI based on the
+        // current data stored in the manager.
         foreach (Transform child in itemContainer)
             Destroy(child.gameObject);
         if (completedItemContainer != null)

--- a/Assets/1-Scripts/SwipeToDelete/SwipeToDeleteItem.cs
+++ b/Assets/1-Scripts/SwipeToDelete/SwipeToDeleteItem.cs
@@ -60,8 +60,10 @@ public class SwipeToDeleteItem : MonoBehaviour, IPointerDownHandler, IDragHandle
         {
             Debug.Log("💥 Item eliminado por swipe");
             swipePerformed = true;
+            // Notify listeners that a delete action was requested so that
+            // higher-level components can update data and remove the UI item
+            // themselves.
             onDelete.Invoke();
-            Destroy(gameObject.transform.parent.gameObject);
         }
         else if (finalDelta >= deleteThreshold)
         {


### PR DESCRIPTION
## Summary
- route swipe deletion through an event instead of destroying the item directly
- let ShoppingListItemUI remove itself after updating the manager
- document full UI rebuild from manager data

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_b_6891c4e8558083269717c3b7a26759f2